### PR TITLE
set password maxSize to 32

### DIFF
--- a/NKNMining/web/src/pages/nsSetup/nsLoadWallet.vue
+++ b/NKNMining/web/src/pages/nsSetup/nsLoadWallet.vue
@@ -87,7 +87,7 @@
             placeholder: this.$t('nsInput.walletPassword.placeholder'),
             hasAppend: false,
             inputType: 'password',
-            maxSize: 20,
+            maxSize: 32,
             errorInfo: '',
           },
 
@@ -122,7 +122,7 @@
             placeholder: this.$t('nsInput.walletPassword.placeholder'),
             hasAppend: false,
             inputType: 'password',
-            maxSize: 20,
+            maxSize: 32,
             errorInfo: '',
           },
 


### PR DESCRIPTION
The password generated by the DigitalOcean nkn image has a length of 32 so trying to copy the password into field which is currently set at a maxlength of 20 truncates it.